### PR TITLE
WIP fixing profiling nginx in a container

### DIFF
--- a/profiler/Makefile
+++ b/profiler/Makefile
@@ -12,7 +12,7 @@ HELPERS := $(abspath ../helpers)
 # Use our own libbpf API headers and Linux UAPI headers distributed with
 # libbpf to avoid dependency on system-wide headers, which could be missing or
 # outdated
-INCLUDES := -I$(OUTPUT) -I../libbpf/include/uapi -I$(dir $(VMLINUX)) -I$(HELPERS)
+INCLUDES := -I$(OUTPUT) -I../libbpf/include/uapi -I../vmlinux/x86 -I$(HELPERS)
 CFLAGS := -g -Wall # -fsanitize=address
 
 APPS = profile
@@ -45,7 +45,7 @@ all: $(APPS)
 
 $(VMLINUX):
 	$(Q)wget https://github.com/yunwei37/apisix-profiler/releases/download/vmlinux/vmlinux.tar
-	$(Q)tar -xvf vmlinux.tar ../
+	$(Q)tar -xvf vmlinux.tar -C ../
 	$(Q)rm vmlinux.tar
 
 .PHONY: clean


### PR DESCRIPTION
This is a draft, not ready for review yet.

I was attempting to use this tool to profile an nginx instance running in a container, but many of the ELF helpers don't understand how to deal with containerized paths.

The fix for this is relatively simple, we just prepend `/proc/PID/root` to the paths, to make them relative to the target pid's mount namespace.

Since the helpers don't take a `pid`, for now I've hacked it by adding a static variable and storing this early on when we are looking for the lib / binary to profile.

After these changes, I am able to profile an nginx instance running in a container, provided I have access to the root pid namespace.

I also discovered an issue with the makefile, which I will PR separately but is currently included in this branch.


- [ ] Look into cleaner way to obtain the PID than storing in a static variable
- [ ] Create mount namespace helpers rather than duplicating the code
- [ ] Tests?
- [ ] Whitespace fixes / formatting
- [ ] Create separate PR for makefile fix