### PR TITLE
Fix: folded format & lookup_batch error 

### DIFF
--- a/profiler/Makefile
+++ b/profiler/Makefile
@@ -7,12 +7,12 @@ BPFTOOL ?= $(abspath ../tools/bpftool)
 LIBBPF_SRC := $(abspath ../libbpf/src)
 LIBBPF_OBJ := $(abspath $(OUTPUT)/libbpf.a)
 ARCH := $(shell uname -m | sed 's/x86_64/x86/' | sed 's/aarch64/arm64/' | sed 's/ppc64le/powerpc/' | sed 's/mips.*/mips/')
-VMLINUX := $(ARCH)/$(ARCH)/vmlinux.h
+VMLINUX := ../vmlinux/$(ARCH)/
 HELPERS := $(abspath ../helpers)
 # Use our own libbpf API headers and Linux UAPI headers distributed with
 # libbpf to avoid dependency on system-wide headers, which could be missing or
 # outdated
-INCLUDES := -I$(OUTPUT) -I../libbpf/include/uapi -I$(dir $(VMLINUX)) -I$(HELPERS)
+INCLUDES := -I$(OUTPUT) -I../libbpf/include/uapi -I$(VMLINUX) -I$(HELPERS)
 CFLAGS := -g -Wall # -fsanitize=address
 
 APPS = profile
@@ -45,7 +45,7 @@ all: $(APPS)
 
 $(VMLINUX):
 	$(Q)wget https://github.com/yunwei37/apisix-profiler/releases/download/vmlinux/vmlinux.tar
-	$(Q)tar -xvf vmlinux.tar ../
+	$(Q)tar -xvf vmlinux.tar -C ../
 	$(Q)rm vmlinux.tar
 
 .PHONY: clean


### PR DESCRIPTION

## 环境

```
Linux  5.15.0-1047-gcp #55~20.04.1-Ubuntu SMP Wed Nov 15 11:38:25 UTC 2023 x86_64 x86_64 x86_64 GNU/Linux
```


## 当前存以下几个问题 

1.  Makefile 路径不对，导致无法正常编译
2. 当使用 ford 格式的时候，如果 nr_kip = 0; **std::size_t**  类型会出现异常，出现 j -1 则会发生下溢（underflow）;
`从而导致死循环`！直到出现错误内核抛堆栈异常。
**解决方案：**
把 `std::size_t `这个类型 改成跟其他是一致的 `int` 类型 。

3. **当前使用的是 _**batch_map_ops=true**_ 批量获取的方式，这里存在几个问题**：
3.1 使用 **bpf_map_lookup_batch** 的异常， 参数 keys 和 vals 的参数有些问题
 * @param keys pointer to an array large enough for *count* keys
 * @param values pointer to an array large enough for *count* values
 
 **解决方案：**
 参考：
 https://github.com/iovisor/bcc/blob/6fbcf16b4a4222b2ea92ea32ceed2532a28b8080/libbpf-tools/map_helpers.c#L58
 
改成
 ```
keys +  n_read * sizeof(stack_key)
 ```
 
 
 3.2 使用 **bpf_map_lookup_batch** 的异常，没有添加 BPF_F_LOCK，`counts map 导致 value 出现 0 的情况`,
 
 
<img width="950" alt="image" src="https://github.com/apache/apisix-profiler/assets/6245343/bc1ca5d1-2f20-4434-bdfe-c7944f5ac911">

 但是直接用bpftool 

```
 ./bpftool map dump  name counts
```
显示正常的，因为 bpftool 使用的是 iter 遍历的方式
<img width="756" alt="image" src="https://github.com/apache/apisix-profiler/assets/6245343/01c1f17d-05be-4354-b78b-2d831331804d">
（https://github.com/libbpf/bpftool/blob/3e6f814e534421c4fd638c1bffc7e8318da78d16/src/map.c#L823）


使用 GDB attach bpf_map_lookup_batch 调用出来就是会出现 0 的情况

<img width="857" alt="image" src="https://github.com/apache/apisix-profiler/assets/6245343/462c8919-8bd3-49eb-839c-3988392cd30f">


深入内核代码 https://elixir.bootlin.com/linux/v5.15/source/kernel/bpf/hashtab.c#L1585



<img width="1006" alt="image" src="https://github.com/apache/apisix-profiler/assets/6245343/dbcb4480-0982-4a80-988d-f3753ea8d27f">

https://elixir.bootlin.com/linux/v5.15/source/kernel/bpf/hashtab.c#L1722

同时遍历的时候，也是有 添加锁的
<img width="818" alt="image" src="https://github.com/apache/apisix-profiler/assets/6245343/f5b322b1-829f-42ee-8987-c36a27e844ee">


https://elixir.bootlin.com/linux/v5.15/source/kernel/bpf/syscall.c#L1262


 **解决方案：**

添加batch_opts 之后测试正常 
```

    // BPF_F_LOCK 
       const struct bpf_map_batch_opts batch_opts = {
         .sz         = sizeof(struct stack_key),  
        .elem_flags = BPF_F_LOCK, 
    };
    

```
**测试结果**
      ./profile -K -p129677 

<img width="688" alt="image" src="https://github.com/apache/apisix-profiler/assets/6245343/1eb2640e-e620-4095-bddd-ffee064218f6">








