### PR TITLE
fix: compile error

### DIFF
--- a/profiler/Makefile
+++ b/profiler/Makefile
@@ -7,7 +7,7 @@ BPFTOOL ?= $(abspath ../tools/bpftool)
 LIBBPF_SRC := $(abspath ../libbpf/src)
 LIBBPF_OBJ := $(abspath $(OUTPUT)/libbpf.a)
 ARCH := $(shell uname -m | sed 's/x86_64/x86/' | sed 's/aarch64/arm64/' | sed 's/ppc64le/powerpc/' | sed 's/mips.*/mips/')
-VMLINUX := $(ARCH)/$(ARCH)/vmlinux.h
+VMLINUX := ../vmlinux/$(ARCH)/vmlinux.h
 HELPERS := $(abspath ../helpers)
 # Use our own libbpf API headers and Linux UAPI headers distributed with
 # libbpf to avoid dependency on system-wide headers, which could be missing or
@@ -45,7 +45,7 @@ all: $(APPS)
 
 $(VMLINUX):
 	$(Q)wget https://github.com/yunwei37/apisix-profiler/releases/download/vmlinux/vmlinux.tar
-	$(Q)tar -xvf vmlinux.tar ../
+	$(Q)tar -xvf vmlinux.tar -C ../
 	$(Q)rm vmlinux.tar
 
 .PHONY: clean


### PR DESCRIPTION

1.
```
Saving to: ‘vmlinux.tar’

vmlinux.tar           100%[============================================================>]   8.22M   606KB/s    in 15s

2024-12-24 04:00:36 (559 KB/s) - ‘vmlinux.tar’ saved [8622080/8622080]

tar: ..: Not found in archive
tar: Exiting with failure status due to previous errors
make: *** [Makefile:48: x86/x86/vmlinux.h] Error 2
```

2.
```
  BPF      .output/profile.bpf.o
In file included from profile.bpf.c:3:
./lua_state.h:12:10: fatal error: 'vmlinux.h' file not found
#include <vmlinux.h>
         ^~~~~~~~~~~
1 error generated.
make: *** [Makefile:71: .output/profile.bpf.o] Error 1
```